### PR TITLE
Fix NPE on reconnection with active subscriptions

### DIFF
--- a/contrib/mqlight/java/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
+++ b/contrib/mqlight/java/mqlight/src/main/java/com/ibm/mqlight/api/impl/NonBlockingClientImpl.java
@@ -559,8 +559,10 @@ public class NonBlockingClientImpl extends NonBlockingClient implements FSMActio
             SubscribeResponse sr = (SubscribeResponse)message;
             SubData sd = subscribedDestinations.get(sr.topic);
             if (sd != null) {
-                sd.inProgressSubscribe.future.postSuccess(callbackService);
-                sd.inProgressSubscribe = null;
+                if (sd.inProgressSubscribe != null) {
+                    sd.inProgressSubscribe.future.postSuccess(callbackService);
+                    sd.inProgressSubscribe = null;
+                }
                 sd.state = SubData.State.ESTABLISHED;
                 // Replay any pending operations on the subscription
                 while(!sd.pending.isEmpty()) {


### PR DESCRIPTION
When a connection with active subscriptions to the broker fails and
then reconnects a NPE would occur as there was no attached future
for the subscription.

This would result in the subscriptions not being fully re-established.
